### PR TITLE
Fix file input checks for decode workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,10 +278,14 @@ btnEncode.addEventListener('click', async ()=>{
 
 btnPlay.addEventListener('click', ()=>{ if(player.src) player.play(); });
 
-fileIn.addEventListener('change', ()=>{ btnDecode.disabled = !fileIn.files?.length; decodedPre.textContent=''; });
+fileIn.addEventListener('change', ()=>{
+  const hasFiles = fileIn.files && fileIn.files.length > 0;
+  btnDecode.disabled = !hasFiles;
+  decodedPre.textContent='';
+});
 
 btnDecode.addEventListener('click', async ()=>{
-  const file = fileIn.files?.[0]; if(!file) return;
+  const file = fileIn.files && fileIn.files[0]; if(!file) return;
   btnDecode.disabled = true; decodedPre.textContent='Decoding…';
   try{
     const pass = decPass.value || '';


### PR DESCRIPTION
## Summary
- replace optional chaining in the file input change handler with explicit file list checks
- guard the decode click handler before accessing the first selected file to avoid unsupported syntax

## Testing
- not run (not applicable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d637bbd7b08331a5663b68c4efd0a4