### PR TITLE
Add reusable modal for encoder messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,15 @@
   .switch{display:inline-flex;align-items:center;gap:8px}
   .switch input{width:18px;height:18px}
   input[type="password"], input[type="text"]{border-radius:12px;border:1px solid var(--line);background:#0d1634;color:#eef2ff;padding:10px 12px;outline:none}
+  .modal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(5,10,25,0.78);backdrop-filter:blur(6px);z-index:999;padding:20px;animation:fadeIn 0.2s ease-out}
+  .modal.hidden{display:none}
+  .modal-content{max-width:420px;width:100%;background:var(--card);border:1px solid var(--line);border-radius:16px;box-shadow:0 18px 40px #000a;padding:22px;display:flex;flex-direction:column;gap:16px;animation:slideUp 0.25s ease-out}
+  .modal-content h3{margin:0;font-size:18px}
+  .modal-content p{margin:0;color:var(--ink)}
+  .modal-actions{display:flex;justify-content:flex-end}
+  .hidden{display:none !important}
+  @keyframes fadeIn{from{opacity:0}to{opacity:1}}
+  @keyframes slideUp{from{transform:translateY(16px);opacity:0}to{transform:translateY(0);opacity:1}}
 </style>
 </head>
 <body>
@@ -96,6 +105,15 @@
 
 <footer class="small" style="text-align:center;margin:18px 0 8px">© <span id="year"></span> Sonar • <a href="https://github.com/drs-az/Sonar/" style="text-decoration: none; color:white;" target="_blank">Open Source</a></footer>
 
+    <div id="modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="modal-content">
+        <h3 id="modalTitle">Notice</h3>
+        <p id="modalMessage"></p>
+        <div class="modal-actions">
+          <button id="modalClose" class="btn ghost" type="button">Close</button>
+        </div>
+      </div>
+    </div>
   </div><script>
 // ===== Parameters =====
 const SAMPLE_RATE = 44100;
@@ -242,21 +260,43 @@ const fileIn = document.getElementById('fileIn');
 const decPass = document.getElementById('decPass');
 const btnDecode = document.getElementById('btnDecode');
 const decodedPre = document.getElementById('decoded');
+const modal = document.getElementById('modal');
+const modalMessage = document.getElementById('modalMessage');
+const modalClose = document.getElementById('modalClose');
+
+function showModal(message){
+  modalMessage.textContent = message;
+  modal.classList.remove('hidden');
+  requestAnimationFrame(()=>modalClose.focus());
+}
+
+function hideModal(){
+  modal.classList.add('hidden');
+}
+
+modalClose.addEventListener('click', hideModal);
+modal.addEventListener('click', (event)=>{ if(event.target === modal) hideModal(); });
+window.addEventListener('keydown', (event)=>{ if(event.key === 'Escape' && !modal.classList.contains('hidden')) hideModal(); });
 
 let currentUrl = null;
 
 btnEncode.addEventListener('click', async ()=>{
-  btnEncode.disabled = true; decodedPre.textContent='';
+  const pass = encPass.value || '';
+  if(!pass) {
+    showModal('Passphrase is required to create the WAV.');
+    return;
+  }
+
+  btnEncode.disabled = true;
+  decodedPre.textContent='';
   try{
-    const pass = encPass.value || '';
-    if(!pass) { alert('Passphrase is required to create the WAV.'); return; }
     const plaintext = textIn.value || 'HELLO WORLD';
     const payload = await aesEncrypt(plaintext, pass); // Base32 (A–Z,2–7)
     const audio = encodeTextToAudio(payload);
     const blob = encodeWAV(audio, SAMPLE_RATE);
     if(currentUrl) URL.revokeObjectURL(currentUrl); currentUrl = URL.createObjectURL(blob);
     player.src = currentUrl; btnPlay.disabled = false; downloadLink.href = currentUrl; downloadLink.style.display='inline-flex';
-  }catch(e){ alert('Encode error: '+ (e.message||e)); }
+  }catch(e){ showModal('Encode error: ' + (e.message||e)); }
   finally{ btnEncode.disabled = false; }
 });
 


### PR DESCRIPTION
## Summary
- add a reusable modal overlay with styling and markup for messaging
- provide showModal/hideModal helpers and replace alert usage in the encoder flow
- validate the passphrase before disabling the encode button so modal messaging leaves controls usable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6a3539cd48331b502a2f5dfa47f0e