### PR TITLE
Add passphrase visibility toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,11 @@
   .kbd{background:#0e1735;border:1px solid #2b3a73;border-radius:6px;padding:2px 6px;font-family:ui-monospace,Menlo,Consolas,monospace;color:#dfe7ff}
   .mono{font-family:ui-monospace,Menlo,Consolas,monospace}
   .field{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+  .password-field{flex:1;display:flex;align-items:center;gap:8px}
+  .password-field input{flex:1}
+  .pass-toggle{appearance:none;border:1px solid var(--line);border-radius:10px;padding:8px 12px;background:#162650;color:var(--ink);font-weight:600;font-size:12px;cursor:pointer;transition:background 0.2s ease}
+  .pass-toggle:hover{background:#1f3167}
+  .pass-toggle:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
   .switch{display:inline-flex;align-items:center;gap:8px}
   .switch input{width:18px;height:18px}
   input[type="password"], input[type="text"]{border-radius:12px;border:1px solid var(--line);background:#0d1634;color:#eef2ff;padding:10px 12px;outline:none}
@@ -66,7 +71,10 @@
     <textarea id="textIn" placeholder="HELLO WORLD FROM DOM">HELLO WORLD FROM DOM</textarea>
     <div class="field" style="margin-top:10px">
       <label for="encPass" class="small">Passphrase (required)</label>
-      <input type="password" id="encPass" placeholder="Enter passphrase" autocomplete="new-password" required />
+      <div class="password-field">
+        <input type="password" id="encPass" placeholder="Enter passphrase" autocomplete="new-password" required />
+        <button type="button" class="pass-toggle" data-target="encPass" data-show-label="Show passphrase for encoding" data-hide-label="Hide passphrase for encoding" aria-label="Show passphrase for encoding" aria-pressed="false">Show</button>
+      </div>
     </div>
     <div class="row" style="margin-top:12px">
       <button id="btnEncode" class="btn">Generate WAV</button>
@@ -86,7 +94,10 @@
     <input type="file" id="fileIn" accept="audio/*" />
     <div class="field" style="margin-top:10px">
       <label for="decPass" class="small">Passphrase (required)</label>
-      <input type="password" id="decPass" placeholder="Enter passphrase" autocomplete="current-password" required />
+      <div class="password-field">
+        <input type="password" id="decPass" placeholder="Enter passphrase" autocomplete="current-password" required />
+        <button type="button" class="pass-toggle" data-target="decPass" data-show-label="Show passphrase for decoding" data-hide-label="Hide passphrase for decoding" aria-label="Show passphrase for decoding" aria-pressed="false">Show</button>
+      </div>
     </div>
     <div class="row" style="margin-top:12px">
       <button id="btnDecode" class="btn" disabled>Decode</button>
@@ -263,6 +274,38 @@ const decodedPre = document.getElementById('decoded');
 const modal = document.getElementById('modal');
 const modalMessage = document.getElementById('modalMessage');
 const modalClose = document.getElementById('modalClose');
+const passToggleButtons = document.querySelectorAll('.pass-toggle');
+
+passToggleButtons.forEach((button)=>{
+  const targetId = button.dataset.target;
+  const input = targetId ? document.getElementById(targetId) : null;
+  if(!input) return;
+
+  const updateState = ()=>{
+    const isText = input.type === 'text';
+    button.textContent = isText ? 'Hide' : 'Show';
+    button.setAttribute('aria-pressed', isText ? 'true' : 'false');
+    const label = isText ? button.dataset.hideLabel : button.dataset.showLabel;
+    if(label) button.setAttribute('aria-label', label);
+  };
+
+  button.addEventListener('click', ()=>{
+    const shouldReveal = input.type === 'password';
+    input.type = shouldReveal ? 'text' : 'password';
+    updateState();
+    try{
+      input.focus({preventScroll:true});
+    }catch(_){
+      input.focus();
+    }
+    if(input.type === 'text'){
+      const length = input.value.length;
+      try{ input.setSelectionRange(length, length); }catch(_){ /* no-op */ }
+    }
+  });
+
+  updateState();
+});
 
 function showModal(message){
   modalMessage.textContent = message;


### PR DESCRIPTION
## Summary
- wrap the passphrase inputs with a dedicated container and add show/hide controls
- add styling and scripting to toggle passphrase visibility with accessible labels and focus management

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68d6a80f6e10833198c67fc6fe1eaf90