### PR TITLE
Refine encoder action layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,18 @@
   textarea, input[type="file"], .text{width:100%}
   textarea{min-height:110px;padding:14px;border-radius:12px;border:1px solid var(--line);background:#0d1634;color:var(--ink);outline:none}
   .row{display:flex;flex-wrap:wrap;gap:10px;align-items:center}
+  .action-block{margin-top:12px;display:flex;flex-direction:column;gap:12px}
+  .primary-action .btn{width:100%;box-shadow:0 8px 24px #4a87ff55}
+  .secondary-actions{display:flex;flex-wrap:wrap;gap:8px;padding:8px;border-radius:14px;background:#0e1a3f;border:1px solid var(--line);box-shadow:0 6px 20px #0004}
+  .secondary-actions > *{flex:1 1 calc(50% - 8px);text-align:center}
+  @media (max-width:480px){
+    .secondary-actions{padding:8px 10px}
+    .secondary-actions > *{flex:1 1 100%}
+  }
+  @media (min-width:720px){
+    .secondary-actions{flex-wrap:nowrap;justify-content:flex-start;gap:10px}
+    .secondary-actions > *{flex:0 0 auto}
+  }
   .btn{appearance:none;border:none;border-radius:12px;padding:12px 16px;background:linear-gradient(180deg,#4b87ff,#2a67f7);color:#fff;font-weight:700;cursor:pointer;box-shadow:0 6px 18px #4a87ff55}
   .btn[disabled]{opacity:.55;cursor:not-allowed}
   .btn.ghost{background:#162650;border:1px solid var(--line);box-shadow:none}
@@ -83,11 +95,15 @@
       </div>
       <div id="encPassFeedback" class="strength-indicator"></div>
     </div>
-    <div class="row" style="margin-top:12px">
-      <button id="btnEncode" class="btn">Generate WAV</button>
-      <button id="btnPlay" class="btn ghost" disabled>Play</button>
-      <a id="downloadLink" class="btn ghost" download="sonar.wav" style="text-decoration:none;display:none">Download WAV</a>
-      <button id="shareLink" class="btn ghost" type="button" style="display:none">Share WAV</button>
+    <div class="action-block">
+      <div class="primary-action">
+        <button id="btnEncode" class="btn">Generate WAV</button>
+      </div>
+      <div class="secondary-actions">
+        <button id="btnPlay" class="btn ghost" disabled>Play</button>
+        <a id="downloadLink" class="btn ghost" download="sonar.wav" style="text-decoration:none;display:none">Download WAV</a>
+        <button id="shareLink" class="btn ghost" type="button" style="display:none">Share WAV</button>
+      </div>
     </div>
     <div style="height:10px"></div>
     <audio id="player" controls></audio>


### PR DESCRIPTION
## Summary
- restructure the encode action controls so the primary button stands alone and secondary actions share a tray
- add responsive styling for the new action block to keep buttons aligned across screen sizes

## Testing
- manual verification in browser at ~1280px and ~360px widths

------
https://chatgpt.com/codex/tasks/task_e_68d6b55b54648331811f964fd149e3b5